### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Remote.js is a library for developing remote controlled web apps. It is wireless
 
 ## Quick demo
 
-**Note**: Apps tested on Google Chrome only. If the examples don't work, try restarting the browser.
+**Note**: Apps were tested on Google Chrome only. If the examples don't work, try restarting the browser.
 
-* [Open the demo app on your desktop / laptop](http://hacksparrow.github.io/remote.js/example/controlled.html)
-* [Open the remote controller app on your smartphone](http://hacksparrow.github.io/remote.js/example/controller.html)
+* [Open the remote controller app on your smartphone](https://hacksparrow.github.io/remote.js/example/controller.html)
+* [Open the demo app on your desktop / laptop](https://hacksparrow.github.io/remote.js/example/controlled.html)
 
 Once the apps are loaded, point the remote at the demo, and press the buttons.
 


### PR DESCRIPTION
The links to the demo applications need to be https. Chrome no longer allows http. This was a security upgrade change Chrome mandated. If the objects are not created under https then you get an alert that says "hacksparrow.github.io says: object NavigatorUserMediaError".

Navigating to https://hacksparrow.github.io/remote.js/example/controlled.html fixes the problem.